### PR TITLE
feat(cli): add markdown-to-doc CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to `markdown-to-doc` should be documented in this file.
 
 The format is based on Keep a Changelog and this project uses semantic versioning.
 
+## [Unreleased]
+
 ### Added
 
 - Added standard open source project files, including `LICENSE`,
   `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`.
 - Added GitHub collaboration scaffolding with issue templates, a pull request
   template, CODEOWNERS, and Dependabot configuration.
+- Added CLI support through the `markdown-to-doc` binary for file input, stdin, JSON config loading, and explicit help/version commands.
+- Added end-to-end CLI tests covering success paths and argument/config validation.
 
 ### Changed
 
@@ -17,6 +21,8 @@ The format is based on Keep a Changelog and this project uses semantic versionin
   permissions.
 - Updated the publish workflow to publish with npm provenance.
 - Updated the README with links to project governance and contribution docs.
+- Updated package build and publish metadata to ship the CLI binary.
+- Updated the README with CLI installation, usage, config examples, and behavior notes.
 
 ## [1.0.1] - 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It is built for application-driven document generation:
 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [CLI](#cli)
 - [What The Package Does](#what-the-package-does)
 - [API](#api)
 - [Configuration](#configuration)
@@ -69,6 +70,12 @@ It is built for application-driven document generation:
 npm install markdown-to-doc
 ```
 
+For CLI usage:
+
+```bash
+npm install -g markdown-to-doc
+```
+
 ## Quick Start
 
 ```ts
@@ -92,6 +99,70 @@ const buffer = await markdownToDocx(markdown);
 
 await writeFile("output.docx", buffer);
 ```
+
+## CLI
+
+The package also ships with a `markdown-to-doc` CLI for file-based conversion.
+
+### Basic Usage
+
+Convert a markdown file and write `output.docx` next to it:
+
+```bash
+markdown-to-doc ./output.md
+```
+
+Choose the output path explicitly:
+
+```bash
+markdown-to-doc ./report.md --output ./dist/report.docx
+```
+
+Read markdown from stdin:
+
+```bash
+cat ./report.md | markdown-to-doc --stdin --output ./report.docx
+```
+
+Load document options from JSON:
+
+```bash
+markdown-to-doc ./report.md --config ./doc-config.json
+```
+
+### CLI Config
+
+`--config` accepts a JSON object shaped like `MarkdownToDocxOptions`.
+
+Example:
+
+```json
+{
+  "cover": {
+    "show": true,
+    "title": "Quarterly Report"
+  },
+  "toc": {
+    "show": true
+  },
+  "footer": {
+    "show": true,
+    "right": {
+      "type": "pageNumber",
+      "format": "currentOfTotal"
+    }
+  }
+}
+```
+
+CLI config supports JSON-serializable options only. Function-based options such as `assets.resolveImage` remain library-only.
+
+### CLI Notes
+
+- File input defaults the output path to the same basename with a `.docx` extension.
+- `--stdin` requires `--output`.
+- Relative markdown and asset paths resolve from the input markdown file when one is provided.
+- Run `markdown-to-doc --help` to see the full usage summary.
 
 ## What The Package Does
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "markdown-to-doc": "./dist/cli/index.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Nilesh9106/markdown-to-doc.git"
@@ -53,7 +56,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "bunx --bun tsup src/index.ts --format esm,cjs --dts --clean",
+    "build": "bunx --bun tsup src/index.ts --format esm,cjs --dts --clean && bunx --bun tsup src/cli/index.ts --format esm --out-dir dist/cli",
     "example": "bun run examples/markdown-to-docx.ts",
     "test": "bun test",
     "typecheck": "bunx --bun tsc --noEmit",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import JSZip from "jszip";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const tempDirectories: string[] = [];
+
+interface CliResult {
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        force: true,
+        recursive: true,
+      }),
+    ),
+  );
+});
+
+async function createTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "markdown-to-doc-cli-"));
+  tempDirectories.push(directory);
+  return directory;
+}
+
+async function runCli(args: string[], stdin?: string): Promise<CliResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, ["run", "./src/cli/index.ts", ...args], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: "pipe",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolvePromise({ code, stderr, stdout });
+    });
+
+    if (stdin !== undefined) {
+      child.stdin.end(stdin);
+      return;
+    }
+
+    child.stdin.end();
+  });
+}
+
+async function readDocxText(docxPath: string, filePath: string): Promise<string> {
+  const zip = await JSZip.loadAsync(await readFile(docxPath));
+  const file = zip.file(filePath);
+
+  if (!file) {
+    throw new Error(`Missing DOCX entry: ${filePath}`);
+  }
+
+  return file.async("text");
+}
+
+describe("CLI", () => {
+  it("converts a markdown file and writes the default output path", async () => {
+    const directory = await createTempDirectory();
+    const inputPath = join(directory, "report.md");
+
+    await Bun.write(inputPath, "# Hello from CLI");
+
+    const result = await runCli([inputPath]);
+    const outputPath = join(directory, "report.docx");
+    const documentXml = await readDocxText(outputPath, "word/document.xml");
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain(outputPath);
+    expect(documentXml).toContain("Hello from CLI");
+  });
+
+  it("converts markdown from stdin when an explicit output path is provided", async () => {
+    const directory = await createTempDirectory();
+    const outputPath = join(directory, "stdin-output.docx");
+
+    const result = await runCli(["--stdin", "--output", outputPath], "# Streamed Input");
+    const documentXml = await readDocxText(outputPath, "word/document.xml");
+
+    expect(result.code).toBe(0);
+    expect(documentXml).toContain("Streamed Input");
+  });
+
+  it("applies JSON config values during conversion", async () => {
+    const directory = await createTempDirectory();
+    const inputPath = join(directory, "configurable.md");
+    const outputPath = join(directory, "configured.docx");
+    const configPath = join(directory, "options.json");
+
+    await Bun.write(inputPath, "# Body");
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        cover: {
+          show: true,
+          title: "Configured Cover",
+        },
+      }),
+    );
+
+    const result = await runCli([inputPath, "--output", outputPath, "--config", configPath]);
+    const documentXml = await readDocxText(outputPath, "word/document.xml");
+
+    expect(result.code).toBe(0);
+    expect(documentXml).toContain("Configured Cover");
+    expect(documentXml).toContain("Body");
+  });
+
+  it("fails when stdin and an input file are provided together", async () => {
+    const directory = await createTempDirectory();
+    const inputPath = join(directory, "invalid.md");
+
+    await Bun.write(inputPath, "# Invalid");
+
+    const result = await runCli([inputPath, "--stdin", "--output", join(directory, "out.docx")]);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Use either an input file or --stdin, not both.");
+  });
+
+  it("rejects CLI config fields that require the library API", async () => {
+    const directory = await createTempDirectory();
+    const inputPath = join(directory, "input.md");
+    const configPath = join(directory, "invalid-config.json");
+
+    await Bun.write(inputPath, "# Invalid Config");
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        cover: {
+          logo: {
+            kind: "buffer",
+            value: [1, 2, 3],
+          },
+        },
+      }),
+    );
+
+    const result = await runCli([inputPath, "--config", configPath]);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('kind "buffer"');
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,293 @@
 #!/usr/bin/env node
 
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, extname, resolve } from "node:path";
+import process from "node:process";
+import { MarkdownToDocError } from "../errors/MarkdownToDocError.js";
+import { markdownToDocx } from "../markdown-to-doc.js";
+import type { MarkdownToDocxOptions } from "../types/markdown-to-doc.types.js";
+
+interface CliArguments {
+  configPath?: string;
+  help: boolean;
+  inputPath?: string;
+  outputPath?: string;
+  stdin: boolean;
+  version: boolean;
+}
+
+const HELP_TEXT = `markdown-to-doc
+
+Convert Markdown files into DOCX from the command line.
+
+Usage:
+  markdown-to-doc <input.md> [-o output.docx] [--config options.json]
+  markdown-to-doc --stdin -o output.docx [--config options.json]
+  markdown-to-doc --help
+  markdown-to-doc --version
+
+Options:
+  -o, --output <file>   Write the DOCX file to this path
+  --config <file>       Load MarkdownToDocxOptions from a JSON file
+  --stdin               Read markdown from stdin instead of a file
+  -h, --help            Show this help message
+  -v, --version         Show the current package version
+
+Notes:
+  - When the input is a file, the output defaults to the same path with a .docx extension.
+  - When using --stdin, --output is required.
+  - CLI config supports JSON-serializable options only. Function-based options such as assets.resolveImage are library-only.
+`;
+
 async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  console.log(args);
+  try {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.help) {
+      process.stdout.write(`${HELP_TEXT}\n`);
+      return;
+    }
+
+    if (args.version) {
+      process.stdout.write(`${await readPackageVersion()}\n`);
+      return;
+    }
+
+    const inputPath = args.inputPath ? resolve(args.inputPath) : undefined;
+    const configPath = args.configPath ? resolve(args.configPath) : undefined;
+    const outputPath = resolveOutputPath(inputPath, args.outputPath);
+    const markdown = args.stdin
+      ? await readMarkdownFromStdin()
+      : await readMarkdownFromFile(inputPath);
+    const config = configPath ? await readConfig(configPath) : {};
+    const options = mergeCliOptions(config, inputPath, configPath);
+    const buffer = await markdownToDocx(markdown, options);
+
+    await writeFile(outputPath, buffer);
+    process.stdout.write(`Wrote ${outputPath}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown CLI error.";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv: string[]): CliArguments {
+  const args: CliArguments = {
+    help: false,
+    stdin: false,
+    version: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === undefined) {
+      continue;
+    }
+
+    if (arg === "-h" || arg === "--help") {
+      args.help = true;
+      continue;
+    }
+
+    if (arg === "-v" || arg === "--version") {
+      args.version = true;
+      continue;
+    }
+
+    if (arg === "--stdin") {
+      args.stdin = true;
+      continue;
+    }
+
+    if (arg === "-o" || arg === "--output") {
+      const value = argv[index + 1];
+
+      if (!value || value.startsWith("-")) {
+        throw new MarkdownToDocError(`Missing value for ${arg}.`);
+      }
+
+      args.outputPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--config") {
+      const value = argv[index + 1];
+
+      if (!value || value.startsWith("-")) {
+        throw new MarkdownToDocError("Missing value for --config.");
+      }
+
+      args.configPath = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new MarkdownToDocError(`Unknown option: ${arg}`);
+    }
+
+    if (args.inputPath) {
+      throw new MarkdownToDocError("Only one input markdown file can be provided.");
+    }
+
+    args.inputPath = arg;
+  }
+
+  if (args.help || args.version) {
+    return args;
+  }
+
+  if (args.stdin && args.inputPath) {
+    throw new MarkdownToDocError("Use either an input file or --stdin, not both.");
+  }
+
+  if (!args.stdin && !args.inputPath) {
+    throw new MarkdownToDocError("Provide an input markdown file or use --stdin.");
+  }
+
+  if (args.stdin && !args.outputPath) {
+    throw new MarkdownToDocError("--output is required when using --stdin.");
+  }
+
+  return args;
+}
+
+async function readPackageVersion(): Promise<string> {
+  const packageJsonPath = new URL("../../package.json", import.meta.url);
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as { version?: unknown };
+
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new MarkdownToDocError("Unable to determine the package version.");
+  }
+
+  return packageJson.version;
+}
+
+async function readMarkdownFromFile(inputPath: string | undefined): Promise<string> {
+  if (!inputPath) {
+    throw new MarkdownToDocError("Input markdown file is required.");
+  }
+
+  return readFile(inputPath, "utf8");
+}
+
+async function readMarkdownFromStdin(): Promise<string> {
+  process.stdin.setEncoding("utf8");
+
+  let markdown = "";
+
+  for await (const chunk of process.stdin) {
+    markdown += chunk;
+  }
+
+  return markdown;
+}
+
+function resolveOutputPath(inputPath: string | undefined, outputPath: string | undefined): string {
+  if (outputPath) {
+    return resolve(outputPath);
+  }
+
+  if (!inputPath) {
+    throw new MarkdownToDocError("Unable to determine the output path.");
+  }
+
+  const extension = extname(inputPath);
+  return extension.length === 0
+    ? `${inputPath}.docx`
+    : `${inputPath.slice(0, -extension.length)}.docx`;
+}
+
+async function readConfig(configPath: string): Promise<MarkdownToDocxOptions> {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(await readFile(configPath, "utf8"));
+  } catch (error) {
+    throw new MarkdownToDocError(`Failed to read CLI config at ${configPath}.`, { cause: error });
+  }
+
+  if (!isRecord(parsed)) {
+    throw new MarkdownToDocError("CLI config must be a JSON object.");
+  }
+
+  validateCliConfig(parsed);
+
+  return parsed as MarkdownToDocxOptions;
+}
+
+function validateCliConfig(config: Record<string, unknown>): void {
+  const assets = asRecord(config.assets);
+
+  if (assets?.resolveImage !== undefined) {
+    throw new MarkdownToDocError(
+      "CLI config does not support assets.resolveImage. Use the library API for function-based image resolution.",
+    );
+  }
+
+  assertSerializableImage("cover.logo", asRecord(config.cover)?.logo);
+  assertSerializableImage("cover.image", asRecord(config.cover)?.image);
+
+  const header = asRecord(config.header);
+  const footer = asRecord(config.footer);
+
+  assertSlotImage("header.left", header?.left);
+  assertSlotImage("header.center", header?.center);
+  assertSlotImage("header.right", header?.right);
+  assertSlotImage("footer.left", footer?.left);
+  assertSlotImage("footer.center", footer?.center);
+  assertSlotImage("footer.right", footer?.right);
+}
+
+function assertSlotImage(label: string, slot: unknown): void {
+  const slotRecord = asRecord(slot);
+
+  if (slotRecord?.type !== "image") {
+    return;
+  }
+
+  assertSerializableImage(`${label}.source`, slotRecord.source);
+}
+
+function assertSerializableImage(label: string, image: unknown): void {
+  const imageRecord = asRecord(image);
+
+  if (imageRecord?.kind === "buffer") {
+    throw new MarkdownToDocError(
+      `CLI config does not support ${label} with kind "buffer". Use "path" or "base64", or call the library API directly.`,
+    );
+  }
+}
+
+function mergeCliOptions(
+  config: MarkdownToDocxOptions,
+  inputPath: string | undefined,
+  configPath: string | undefined,
+): MarkdownToDocxOptions {
+  const configDir = configPath ? dirname(configPath) : process.cwd();
+  const defaultBaseDir = inputPath ? dirname(inputPath) : configDir;
+  const configuredBaseDir = config.assets?.baseDir
+    ? resolve(configDir, config.assets.baseDir)
+    : defaultBaseDir;
+
+  return {
+    ...config,
+    assets: {
+      ...config.assets,
+      baseDir: configuredBaseDir,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
 }
 
 void main();


### PR DESCRIPTION
## Summary
- add a packaged `markdown-to-doc` CLI with file input, stdin support, JSON config loading, and help/version commands
- add end-to-end CLI tests and README usage/config documentation
- update the changelog and split the build so the CLI ships as ESM-only without the `import.meta` CJS warning

## Validation
- bun run lint
- bun run typecheck
- bun test
- bun run build

Closes #4