### PR TITLE
feat: add syntax-highlighted fenced code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog and this project uses semantic versionin
   template, CODEOWNERS, and Dependabot configuration.
 - Added CLI support through the `markdown-to-doc` binary for file input, stdin, JSON config loading, and explicit help/version commands.
 - Added end-to-end CLI tests covering success paths and argument/config validation.
+- Added syntax-highlighted fenced code blocks in generated DOCX output using `lowlight`, with plain-text fallback for unsupported or unknown languages.
 
 ### Changed
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "docx": "^9.5.1",
         "image-size": "^2.0.2",
+        "lowlight": "^3.3.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
@@ -157,6 +158,8 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -215,6 +218,8 @@
 
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
+    "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
     "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
@@ -238,6 +243,8 @@
     "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lowlight": ["lowlight@3.3.0", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/examples/example.md
+++ b/examples/example.md
@@ -1,7 +1,5 @@
 # Product Requirements Document
 
-Stakeholder: Synchrony
-
 ## **Goals**
 
 ### **Business Goals**
@@ -214,6 +212,55 @@ Stakeholder: Synchrony
 | 1 | OpenAPI generation, NL validation, Postman export, net worth & categories | 2 sprints |
 | 2 | Business context, recurring expenses, schedules/filters, reporting | 1–2 sprints |
 | 3 | Orchestration maturity, multi-route complexity, optional tools | 1 sprint |
+
+### **Sample implementation snippets**
+
+```ts
+type ValidationSummary = {
+  assets: number;
+  liabilities: number;
+};
+
+export function calculateNetWorth(summary: ValidationSummary) {
+  return summary.assets - summary.liabilities;
+}
+```
+### JSON example
+
+```json
+{
+  "scenario": "net-worth-reconciliation",
+  "tolerance": 0,
+  "enabled": true
+}
+```
+### Bash example
+
+```bash
+curl -X POST https://api.example.com/validate \
+  -H "content-type: application/json" \
+  -d '{"scenario":"net-worth-reconciliation"}'
+```
+
+### Traceability matrix example
+
+```text
+source meeting/document claim
+        ↓
+Helix memory artifact
+        ↓
+score + reason
+```
+
+Example:
+
+```text
+"Prequalification is not final approval"
+        ↓
+REQ-004 · Prequalification-to-Application Continuity
+        ↓
+matched, grounded, useful
+```
 
 ### **Illustrative figures**
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "docx": "^9.5.1",
     "image-size": "^2.0.2",
+    "lowlight": "^3.3.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -120,9 +120,9 @@ describe("CLI", () => {
     expect(documentXml).toContain("&quot;status&quot;");
     expect(documentXml).toContain("&quot;ok&quot;");
     expect(documentXml).toContain(">2<");
-    expect(documentXml).toContain('w:color w:val="0369A1"');
-    expect(documentXml).toContain('w:color w:val="0F766E"');
-    expect(documentXml).toContain('w:color w:val="B45309"');
+    expect(documentXml).toContain('w:color w:val="6F42C1"');
+    expect(documentXml).toContain('w:color w:val="032F62"');
+    expect(documentXml).toContain('w:color w:val="005CC5"');
   });
 
   it("applies JSON config values during conversion", async () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -102,6 +102,29 @@ describe("CLI", () => {
     expect(documentXml).toContain("Streamed Input");
   });
 
+  it("renders syntax-highlighted code blocks through the CLI", async () => {
+    const directory = await createTempDirectory();
+    const inputPath = join(directory, "snippet.md");
+
+    await Bun.write(
+      inputPath,
+      ["# CLI code sample", "", "```json", '{ "status": "ok", "count": 2 }', "```"].join("\n"),
+    );
+
+    const result = await runCli([inputPath]);
+    const outputPath = join(directory, "snippet.docx");
+    const documentXml = await readDocxText(outputPath, "word/document.xml");
+
+    expect(result.code).toBe(0);
+    expect(documentXml).toContain(">JSON<");
+    expect(documentXml).toContain("&quot;status&quot;");
+    expect(documentXml).toContain("&quot;ok&quot;");
+    expect(documentXml).toContain(">2<");
+    expect(documentXml).toContain('w:color w:val="0369A1"');
+    expect(documentXml).toContain('w:color w:val="0F766E"');
+    expect(documentXml).toContain('w:color w:val="B45309"');
+  });
+
   it("applies JSON config values during conversion", async () => {
     const directory = await createTempDirectory();
     const inputPath = join(directory, "configurable.md");

--- a/src/__tests__/markdown-to-doc.test.ts
+++ b/src/__tests__/markdown-to-doc.test.ts
@@ -85,6 +85,44 @@ describe("markdownToDocx", () => {
     expect(documentXml).not.toContain('w:w="100%"');
   });
 
+  it("renders fenced code blocks with syntax-highlighted runs", async () => {
+    const buffer = await markdownToDocx(
+      ["```ts", "const total = 42;", 'console.log("ready"); // keep me', "```"].join("\n"),
+    );
+
+    const zip = await openDocx(buffer);
+    const documentXml = await readZipText(zip, "word/document.xml");
+
+    expect(documentXml).toContain(">TS<");
+    expect(documentXml).toContain(">const<");
+    expect(documentXml).toContain(">42<");
+    expect(documentXml).toContain(">console<");
+    expect(documentXml).toContain(">log<");
+    expect(documentXml).toContain("&quot;ready&quot;");
+    expect(documentXml).toContain("// keep me");
+    expect(documentXml).toContain('w:shd w:fill="EEF4F8"');
+    expect(documentXml).toContain('w:color w:val="1D4ED8"');
+    expect(documentXml).toContain('w:color w:val="B45309"');
+    expect(documentXml).toContain('w:color w:val="0F766E"');
+    expect(documentXml).toContain('w:color w:val="6B7280"');
+  });
+
+  it("falls back to plain code formatting for unsupported languages", async () => {
+    const buffer = await markdownToDocx(
+      ["```brainflux", "spark -> pulse -> sink", "```"].join("\n"),
+    );
+
+    const zip = await openDocx(buffer);
+    const documentXml = await readZipText(zip, "word/document.xml");
+
+    expect(documentXml).toContain(">BRAINFLUX<");
+    expect(documentXml).toContain("spark -&gt; pulse -&gt; sink");
+    expect(documentXml).toContain('w:shd w:fill="EEF4F8"');
+    expect(documentXml).not.toContain('w:color w:val="1D4ED8"');
+    expect(documentXml).not.toContain('w:color w:val="0F766E"');
+    expect(documentXml).not.toContain('w:color w:val="B45309"');
+  });
+
   it("uses the image resolver for markdown images", async () => {
     let resolverCalls = 0;
 

--- a/src/__tests__/markdown-to-doc.test.ts
+++ b/src/__tests__/markdown-to-doc.test.ts
@@ -101,10 +101,10 @@ describe("markdownToDocx", () => {
     expect(documentXml).toContain("&quot;ready&quot;");
     expect(documentXml).toContain("// keep me");
     expect(documentXml).toContain('w:shd w:fill="EEF4F8"');
-    expect(documentXml).toContain('w:color w:val="1D4ED8"');
-    expect(documentXml).toContain('w:color w:val="B45309"');
-    expect(documentXml).toContain('w:color w:val="0F766E"');
-    expect(documentXml).toContain('w:color w:val="6B7280"');
+    expect(documentXml).toContain('w:color w:val="D73A49"');
+    expect(documentXml).toContain('w:color w:val="005CC5"');
+    expect(documentXml).toContain('w:color w:val="032F62"');
+    expect(documentXml).toContain('w:color w:val="6A737D"');
   });
 
   it("falls back to plain code formatting for unsupported languages", async () => {

--- a/src/markdown-to-doc.ts
+++ b/src/markdown-to-doc.ts
@@ -49,6 +49,7 @@ import type {
   ResolvedMarkdownToDocxOptions,
   TextStyle,
 } from "./types/markdown-to-doc.types.js";
+import { tokenizeCodeBlock } from "./utils/code-highlighting.js";
 import { resolveOptions } from "./utils/default-options.js";
 import { resolveConfiguredImage, resolveMarkdownImage } from "./utils/image.js";
 import { extractText, parseMarkdown } from "./utils/markdown.js";
@@ -876,7 +877,49 @@ function renderCodeBlock(
   language: string | null | undefined,
   context: RenderContext,
 ): Paragraph {
-  const prefix = language ? `${language}\n` : "";
+  const children: ParagraphChild[] = [];
+  const lines = tokenizeCodeBlock(value, language);
+
+  if (language) {
+    children.push(
+      new TextRun({
+        text: language.toUpperCase(),
+        bold: true,
+        color: "5B6574",
+        font: context.options.theme.fonts.mono,
+        size: toHalfPoints(context.options.theme.fontSize.code),
+      }),
+    );
+
+    if (lines.length > 0) {
+      children.push(new TextRun({ break: 1 }));
+    }
+  }
+
+  for (const [lineIndex, line] of lines.entries()) {
+    if (line.length === 0) {
+      if (lineIndex < lines.length - 1) {
+        children.push(new TextRun({ break: 1 }));
+      }
+
+      continue;
+    }
+
+    for (const token of line) {
+      children.push(
+        new TextRun({
+          text: token.text,
+          font: context.options.theme.fonts.mono,
+          color: token.color ?? hex(context.options.theme.colors.text),
+          size: toHalfPoints(context.options.theme.fontSize.code),
+        }),
+      );
+    }
+
+    if (lineIndex < lines.length - 1) {
+      children.push(new TextRun({ break: 1 }));
+    }
+  }
 
   return new Paragraph({
     spacing: {
@@ -892,14 +935,7 @@ function renderCodeBlock(
         size: 6,
       },
     },
-    children: [
-      new TextRun({
-        text: `${prefix}${value}`,
-        font: context.options.theme.fonts.mono,
-        color: hex(context.options.theme.colors.text),
-        size: toHalfPoints(context.options.theme.fontSize.code),
-      }),
-    ],
+    children,
   });
 }
 

--- a/src/markdown-to-doc.ts
+++ b/src/markdown-to-doc.ts
@@ -911,6 +911,8 @@ function renderCodeBlock(
           text: token.text,
           font: context.options.theme.fonts.mono,
           color: token.color ?? hex(context.options.theme.colors.text),
+          bold: token.bold,
+          italics: token.italics,
           size: toHalfPoints(context.options.theme.fontSize.code),
         }),
       );

--- a/src/utils/code-highlighting.ts
+++ b/src/utils/code-highlighting.ts
@@ -1,0 +1,432 @@
+interface CodeToken {
+  text: string;
+  color?: string;
+}
+
+interface TokenRule {
+  pattern: RegExp;
+  color?: string;
+}
+
+const COMMENT_COLOR = "6B7280";
+const STRING_COLOR = "0F766E";
+const NUMBER_COLOR = "B45309";
+const KEYWORD_COLOR = "1D4ED8";
+const IDENTIFIER_COLOR = "7C2D12";
+const BUILTIN_COLOR = "7C3AED";
+const PROPERTY_COLOR = "0369A1";
+
+const STRING_PATTERN = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/y;
+const NUMBER_PATTERN = /\b(?:0x[a-fA-F0-9]+|\d+(?:\.\d+)?)\b/y;
+const IDENTIFIER_PATTERN = /[A-Za-z_$][\w$-]*/y;
+const WHITESPACE_PATTERN = /\s+/y;
+
+const JS_KEYWORDS = new Set([
+  "as",
+  "async",
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "from",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "private",
+  "protected",
+  "public",
+  "readonly",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "type",
+  "typeof",
+  "undefined",
+  "var",
+  "void",
+  "while",
+  "yield",
+]);
+
+const JS_BUILTINS = new Set([
+  "Array",
+  "Boolean",
+  "console",
+  "Date",
+  "JSON",
+  "Map",
+  "Math",
+  "Number",
+  "Object",
+  "Promise",
+  "Set",
+  "String",
+]);
+
+const PYTHON_KEYWORDS = new Set([
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "False",
+  "finally",
+  "for",
+  "from",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "None",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "True",
+  "try",
+  "while",
+  "with",
+  "yield",
+]);
+
+const PYTHON_BUILTINS = new Set([
+  "dict",
+  "enumerate",
+  "len",
+  "list",
+  "print",
+  "range",
+  "set",
+  "str",
+]);
+
+const SHELL_KEYWORDS = new Set([
+  "case",
+  "do",
+  "done",
+  "echo",
+  "elif",
+  "else",
+  "esac",
+  "export",
+  "fi",
+  "for",
+  "function",
+  "if",
+  "in",
+  "local",
+  "then",
+  "unset",
+  "while",
+]);
+
+const JSON_RULES: TokenRule[] = [
+  { pattern: /"(?:\\.|[^"\\])*"(?=\s*:)/y, color: PROPERTY_COLOR },
+  { pattern: STRING_PATTERN, color: STRING_COLOR },
+  { pattern: /\b(?:true|false|null)\b/y, color: KEYWORD_COLOR },
+  { pattern: NUMBER_PATTERN, color: NUMBER_COLOR },
+];
+
+export function tokenizeCodeBlock(
+  value: string,
+  language: string | null | undefined,
+): CodeToken[][] {
+  const normalizedLanguage = normalizeLanguage(language);
+  const lines = value.split("\n");
+
+  return lines.map((line) => tokenizeLine(line, normalizedLanguage));
+}
+
+function normalizeLanguage(language: string | null | undefined): string | null {
+  if (!language) {
+    return null;
+  }
+
+  const normalized = language.toLowerCase();
+
+  if (["js", "jsx", "javascript", "ts", "tsx", "typescript"].includes(normalized)) {
+    return "javascript";
+  }
+
+  if (["json"].includes(normalized)) {
+    return "json";
+  }
+
+  if (["bash", "shell", "sh", "zsh"].includes(normalized)) {
+    return "shell";
+  }
+
+  if (["py", "python"].includes(normalized)) {
+    return "python";
+  }
+
+  return null;
+}
+
+function tokenizeLine(line: string, language: string | null): CodeToken[] {
+  if (line.length === 0) {
+    return [];
+  }
+
+  if (language === "json") {
+    return tokenizeWithRules(line, JSON_RULES);
+  }
+
+  if (language === "shell") {
+    return tokenizeScriptLine(line, "#", SHELL_KEYWORDS);
+  }
+
+  if (language === "python") {
+    return tokenizeScriptLine(line, "#", PYTHON_KEYWORDS, PYTHON_BUILTINS);
+  }
+
+  if (language === "javascript") {
+    return tokenizeScriptLine(line, "//", JS_KEYWORDS, JS_BUILTINS);
+  }
+
+  return [{ text: line }];
+}
+
+function tokenizeWithRules(line: string, rules: TokenRule[]): CodeToken[] {
+  const tokens: CodeToken[] = [];
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    let matched = false;
+
+    for (const rule of rules) {
+      rule.pattern.lastIndex = cursor;
+      const match = rule.pattern.exec(line);
+
+      if (!match) {
+        continue;
+      }
+
+      tokens.push({
+        text: match[0],
+        color: rule.color,
+      });
+      cursor = rule.pattern.lastIndex;
+      matched = true;
+      break;
+    }
+
+    if (matched) {
+      continue;
+    }
+
+    tokens.push({ text: line[cursor] ?? "" });
+    cursor += 1;
+  }
+
+  return coalesceTokens(tokens);
+}
+
+function tokenizeScriptLine(
+  line: string,
+  commentPrefix: string,
+  keywords: Set<string>,
+  builtins?: Set<string>,
+): CodeToken[] {
+  const commentStart = findCommentStart(line, commentPrefix);
+
+  if (commentStart === 0) {
+    return [{ text: line, color: COMMENT_COLOR }];
+  }
+
+  const tokens =
+    commentStart === -1
+      ? tokenizeScriptSegment(line, keywords, builtins)
+      : [
+          ...tokenizeScriptSegment(line.slice(0, commentStart), keywords, builtins),
+          { text: line.slice(commentStart), color: COMMENT_COLOR },
+        ];
+
+  return coalesceTokens(tokens);
+}
+
+function tokenizeScriptSegment(
+  segment: string,
+  keywords: Set<string>,
+  builtins?: Set<string>,
+): CodeToken[] {
+  const tokens: CodeToken[] = [];
+  let cursor = 0;
+
+  while (cursor < segment.length) {
+    WHITESPACE_PATTERN.lastIndex = cursor;
+    const whitespace = WHITESPACE_PATTERN.exec(segment);
+
+    if (whitespace) {
+      tokens.push({ text: whitespace[0] });
+      cursor = WHITESPACE_PATTERN.lastIndex;
+      continue;
+    }
+
+    STRING_PATTERN.lastIndex = cursor;
+    const stringMatch = STRING_PATTERN.exec(segment);
+
+    if (stringMatch) {
+      tokens.push({ text: stringMatch[0], color: STRING_COLOR });
+      cursor = STRING_PATTERN.lastIndex;
+      continue;
+    }
+
+    NUMBER_PATTERN.lastIndex = cursor;
+    const numberMatch = NUMBER_PATTERN.exec(segment);
+
+    if (numberMatch) {
+      tokens.push({ text: numberMatch[0], color: NUMBER_COLOR });
+      cursor = NUMBER_PATTERN.lastIndex;
+      continue;
+    }
+
+    IDENTIFIER_PATTERN.lastIndex = cursor;
+    const identifierMatch = IDENTIFIER_PATTERN.exec(segment);
+
+    if (identifierMatch) {
+      const value = identifierMatch[0];
+      const nextNonSpace = findNextNonSpace(segment, IDENTIFIER_PATTERN.lastIndex);
+      const isCallable = nextNonSpace === "(";
+      const isProperty = cursor > 0 && segment[cursor - 1] === ".";
+
+      tokens.push({
+        text: value,
+        color: isProperty
+          ? PROPERTY_COLOR
+          : keywords.has(value)
+            ? KEYWORD_COLOR
+            : builtins?.has(value)
+              ? BUILTIN_COLOR
+              : isCallable
+                ? IDENTIFIER_COLOR
+                : undefined,
+      });
+      cursor = IDENTIFIER_PATTERN.lastIndex;
+      continue;
+    }
+
+    tokens.push({ text: segment[cursor] ?? "" });
+    cursor += 1;
+  }
+
+  return tokens;
+}
+
+function findCommentStart(line: string, commentPrefix: string): number {
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (character === "\\") {
+        escaped = true;
+        continue;
+      }
+
+      if (character === quote) {
+        quote = null;
+      }
+
+      continue;
+    }
+
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+
+    if (line.startsWith(commentPrefix, index)) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function findNextNonSpace(value: string, start: number): string | null {
+  for (let index = start; index < value.length; index += 1) {
+    const character = value[index];
+
+    if (!character) {
+      continue;
+    }
+
+    if (!/\s/.test(character)) {
+      return character;
+    }
+  }
+
+  return null;
+}
+
+function coalesceTokens(tokens: CodeToken[]): CodeToken[] {
+  const first = tokens[0];
+
+  if (!first) {
+    return tokens;
+  }
+
+  const merged: CodeToken[] = [first];
+
+  for (let index = 1; index < tokens.length; index += 1) {
+    const previous = merged[merged.length - 1];
+    const current = tokens[index];
+
+    if (!previous || !current) {
+      continue;
+    }
+
+    if (previous.color === current.color) {
+      previous.text += current.text;
+      continue;
+    }
+
+    merged.push(current);
+  }
+
+  return merged;
+}

--- a/src/utils/code-highlighting.ts
+++ b/src/utils/code-highlighting.ts
@@ -1,431 +1,220 @@
+import type { Element, RootContent, Text } from "hast";
+import { common, createLowlight } from "lowlight";
+
 interface CodeToken {
   text: string;
   color?: string;
+  bold?: boolean;
+  italics?: boolean;
 }
 
-interface TokenRule {
-  pattern: RegExp;
-  color?: string;
-}
+const lowlight = createLowlight(common);
 
-const COMMENT_COLOR = "6B7280";
-const STRING_COLOR = "0F766E";
-const NUMBER_COLOR = "B45309";
-const KEYWORD_COLOR = "1D4ED8";
-const IDENTIFIER_COLOR = "7C2D12";
-const BUILTIN_COLOR = "7C3AED";
-const PROPERTY_COLOR = "0369A1";
+const TOKEN_COLORS: Record<string, string> = {
+  addition: "22863A",
+  attr: "6F42C1",
+  attribute: "005CC5",
+  built_in: "6F42C1",
+  bullet: "005CC5",
+  class: "E36209",
+  code: "032F62",
+  comment: "6A737D",
+  deletion: "B31D28",
+  doctag: "D73A49",
+  formula: "032F62",
+  function: "6F42C1",
+  keyword: "D73A49",
+  literal: "005CC5",
+  meta: "6A737D",
+  meta_keyword: "D73A49",
+  name: "22863A",
+  number: "005CC5",
+  operator: "D73A49",
+  params: "24292E",
+  property: "005CC5",
+  punctuation: "24292E",
+  quote: "6A737D",
+  regexp: "032F62",
+  section: "6F42C1",
+  selector_attr: "005CC5",
+  selector_class: "6F42C1",
+  selector_id: "005CC5",
+  selector_pseudo: "6F42C1",
+  selector_tag: "22863A",
+  string: "032F62",
+  subst: "24292E",
+  symbol: "005CC5",
+  tag: "22863A",
+  template_tag: "D73A49",
+  template_variable: "E36209",
+  title: "6F42C1",
+  type: "E36209",
+  variable: "E36209",
+};
 
-const STRING_PATTERN = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`/y;
-const NUMBER_PATTERN = /\b(?:0x[a-fA-F0-9]+|\d+(?:\.\d+)?)\b/y;
-const IDENTIFIER_PATTERN = /[A-Za-z_$][\w$-]*/y;
-const WHITESPACE_PATTERN = /\s+/y;
-
-const JS_KEYWORDS = new Set([
-  "as",
-  "async",
-  "await",
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "from",
-  "function",
-  "if",
-  "implements",
-  "import",
-  "in",
-  "instanceof",
-  "interface",
-  "let",
-  "new",
-  "null",
-  "private",
-  "protected",
-  "public",
-  "readonly",
-  "return",
-  "static",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "type",
-  "typeof",
-  "undefined",
-  "var",
-  "void",
-  "while",
-  "yield",
-]);
-
-const JS_BUILTINS = new Set([
-  "Array",
-  "Boolean",
-  "console",
-  "Date",
-  "JSON",
-  "Map",
-  "Math",
-  "Number",
-  "Object",
-  "Promise",
-  "Set",
-  "String",
-]);
-
-const PYTHON_KEYWORDS = new Set([
-  "and",
-  "as",
-  "assert",
-  "async",
-  "await",
-  "break",
-  "class",
-  "continue",
-  "def",
-  "del",
-  "elif",
-  "else",
-  "except",
-  "False",
-  "finally",
-  "for",
-  "from",
-  "if",
-  "import",
-  "in",
-  "is",
-  "lambda",
-  "None",
-  "nonlocal",
-  "not",
-  "or",
-  "pass",
-  "raise",
-  "return",
-  "True",
-  "try",
-  "while",
-  "with",
-  "yield",
-]);
-
-const PYTHON_BUILTINS = new Set([
-  "dict",
-  "enumerate",
-  "len",
-  "list",
-  "print",
-  "range",
-  "set",
-  "str",
-]);
-
-const SHELL_KEYWORDS = new Set([
-  "case",
-  "do",
-  "done",
-  "echo",
-  "elif",
-  "else",
-  "esac",
-  "export",
-  "fi",
-  "for",
-  "function",
-  "if",
-  "in",
-  "local",
-  "then",
-  "unset",
-  "while",
-]);
-
-const JSON_RULES: TokenRule[] = [
-  { pattern: /"(?:\\.|[^"\\])*"(?=\s*:)/y, color: PROPERTY_COLOR },
-  { pattern: STRING_PATTERN, color: STRING_COLOR },
-  { pattern: /\b(?:true|false|null)\b/y, color: KEYWORD_COLOR },
-  { pattern: NUMBER_PATTERN, color: NUMBER_COLOR },
-];
+const STYLE_CLASSES = {
+  emphasis: "italics",
+  strong: "bold",
+} as const;
 
 export function tokenizeCodeBlock(
   value: string,
   language: string | null | undefined,
 ): CodeToken[][] {
-  const normalizedLanguage = normalizeLanguage(language);
-  const lines = value.split("\n");
+  const normalizedLanguage = language?.toLowerCase();
 
-  return lines.map((line) => tokenizeLine(line, normalizedLanguage));
+  if (!normalizedLanguage || !lowlight.registered(normalizedLanguage)) {
+    return splitLines([{ text: value }]);
+  }
+
+  try {
+    const tree = lowlight.highlight(normalizedLanguage, value);
+    return splitLines(flattenTokens(tree.children));
+  } catch {
+    return splitLines([{ text: value }]);
+  }
 }
 
-function normalizeLanguage(language: string | null | undefined): string | null {
-  if (!language) {
-    return null;
+function flattenTokens(
+  nodes: RootContent[],
+  inheritedColor?: string,
+  inheritedStyle?: Pick<CodeToken, "bold" | "italics">,
+): CodeToken[] {
+  const tokens: CodeToken[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "text") {
+      tokens.push(createToken(node, inheritedColor, inheritedStyle));
+      continue;
+    }
+
+    if (node.type === "element") {
+      tokens.push(
+        ...flattenTokens(
+          node.children,
+          resolveColor(node, inheritedColor),
+          resolveStyle(node, inheritedStyle),
+        ),
+      );
+    }
   }
 
-  const normalized = language.toLowerCase();
-
-  if (["js", "jsx", "javascript", "ts", "tsx", "typescript"].includes(normalized)) {
-    return "javascript";
-  }
-
-  if (["json"].includes(normalized)) {
-    return "json";
-  }
-
-  if (["bash", "shell", "sh", "zsh"].includes(normalized)) {
-    return "shell";
-  }
-
-  if (["py", "python"].includes(normalized)) {
-    return "python";
-  }
-
-  return null;
+  return coalesceTokens(tokens);
 }
 
-function tokenizeLine(line: string, language: string | null): CodeToken[] {
-  if (line.length === 0) {
+function createToken(
+  node: Text,
+  color?: string,
+  style?: Pick<CodeToken, "bold" | "italics">,
+): CodeToken {
+  return {
+    text: node.value,
+    color,
+    bold: style?.bold,
+    italics: style?.italics,
+  };
+}
+
+function resolveColor(node: Element, inheritedColor?: string): string | undefined {
+  const classNames = getClassNames(node);
+
+  for (const className of classNames) {
+    const normalized = normalizeClassName(className);
+
+    if (normalized && TOKEN_COLORS[normalized]) {
+      return TOKEN_COLORS[normalized];
+    }
+  }
+
+  return inheritedColor;
+}
+
+function resolveStyle(
+  node: Element,
+  inheritedStyle?: Pick<CodeToken, "bold" | "italics">,
+): Pick<CodeToken, "bold" | "italics"> | undefined {
+  const classNames = getClassNames(node);
+  const nextStyle = {
+    bold: inheritedStyle?.bold,
+    italics: inheritedStyle?.italics,
+  };
+
+  for (const className of classNames) {
+    const normalized = normalizeClassName(className);
+
+    if (!normalized) {
+      continue;
+    }
+
+    if (normalized === STYLE_CLASSES.strong) {
+      nextStyle.bold = true;
+    }
+
+    if (normalized === STYLE_CLASSES.emphasis) {
+      nextStyle.italics = true;
+    }
+  }
+
+  return nextStyle.bold || nextStyle.italics ? nextStyle : inheritedStyle;
+}
+
+function getClassNames(node: Element): string[] {
+  const className = node.properties.className;
+
+  if (!Array.isArray(className)) {
     return [];
   }
 
-  if (language === "json") {
-    return tokenizeWithRules(line, JSON_RULES);
-  }
-
-  if (language === "shell") {
-    return tokenizeScriptLine(line, "#", SHELL_KEYWORDS);
-  }
-
-  if (language === "python") {
-    return tokenizeScriptLine(line, "#", PYTHON_KEYWORDS, PYTHON_BUILTINS);
-  }
-
-  if (language === "javascript") {
-    return tokenizeScriptLine(line, "//", JS_KEYWORDS, JS_BUILTINS);
-  }
-
-  return [{ text: line }];
+  return className.flatMap((value) => (typeof value === "string" ? [value] : []));
 }
 
-function tokenizeWithRules(line: string, rules: TokenRule[]): CodeToken[] {
-  const tokens: CodeToken[] = [];
-  let cursor = 0;
+function normalizeClassName(className: string): string | null {
+  const normalized = className.replace(/^hljs-/, "").replace(/[.-]/g, "_");
+  return normalized.length > 0 ? normalized : null;
+}
 
-  while (cursor < line.length) {
-    let matched = false;
+function splitLines(tokens: CodeToken[]): CodeToken[][] {
+  const lines: CodeToken[][] = [[]];
 
-    for (const rule of rules) {
-      rule.pattern.lastIndex = cursor;
-      const match = rule.pattern.exec(line);
+  for (const token of tokens) {
+    const segments = token.text.split("\n");
 
-      if (!match) {
-        continue;
+    for (const [index, segment] of segments.entries()) {
+      if (segment.length > 0) {
+        lines[lines.length - 1]?.push({
+          text: segment,
+          color: token.color,
+          bold: token.bold,
+          italics: token.italics,
+        });
       }
 
-      tokens.push({
-        text: match[0],
-        color: rule.color,
-      });
-      cursor = rule.pattern.lastIndex;
-      matched = true;
-      break;
-    }
-
-    if (matched) {
-      continue;
-    }
-
-    tokens.push({ text: line[cursor] ?? "" });
-    cursor += 1;
-  }
-
-  return coalesceTokens(tokens);
-}
-
-function tokenizeScriptLine(
-  line: string,
-  commentPrefix: string,
-  keywords: Set<string>,
-  builtins?: Set<string>,
-): CodeToken[] {
-  const commentStart = findCommentStart(line, commentPrefix);
-
-  if (commentStart === 0) {
-    return [{ text: line, color: COMMENT_COLOR }];
-  }
-
-  const tokens =
-    commentStart === -1
-      ? tokenizeScriptSegment(line, keywords, builtins)
-      : [
-          ...tokenizeScriptSegment(line.slice(0, commentStart), keywords, builtins),
-          { text: line.slice(commentStart), color: COMMENT_COLOR },
-        ];
-
-  return coalesceTokens(tokens);
-}
-
-function tokenizeScriptSegment(
-  segment: string,
-  keywords: Set<string>,
-  builtins?: Set<string>,
-): CodeToken[] {
-  const tokens: CodeToken[] = [];
-  let cursor = 0;
-
-  while (cursor < segment.length) {
-    WHITESPACE_PATTERN.lastIndex = cursor;
-    const whitespace = WHITESPACE_PATTERN.exec(segment);
-
-    if (whitespace) {
-      tokens.push({ text: whitespace[0] });
-      cursor = WHITESPACE_PATTERN.lastIndex;
-      continue;
-    }
-
-    STRING_PATTERN.lastIndex = cursor;
-    const stringMatch = STRING_PATTERN.exec(segment);
-
-    if (stringMatch) {
-      tokens.push({ text: stringMatch[0], color: STRING_COLOR });
-      cursor = STRING_PATTERN.lastIndex;
-      continue;
-    }
-
-    NUMBER_PATTERN.lastIndex = cursor;
-    const numberMatch = NUMBER_PATTERN.exec(segment);
-
-    if (numberMatch) {
-      tokens.push({ text: numberMatch[0], color: NUMBER_COLOR });
-      cursor = NUMBER_PATTERN.lastIndex;
-      continue;
-    }
-
-    IDENTIFIER_PATTERN.lastIndex = cursor;
-    const identifierMatch = IDENTIFIER_PATTERN.exec(segment);
-
-    if (identifierMatch) {
-      const value = identifierMatch[0];
-      const nextNonSpace = findNextNonSpace(segment, IDENTIFIER_PATTERN.lastIndex);
-      const isCallable = nextNonSpace === "(";
-      const isProperty = cursor > 0 && segment[cursor - 1] === ".";
-
-      tokens.push({
-        text: value,
-        color: isProperty
-          ? PROPERTY_COLOR
-          : keywords.has(value)
-            ? KEYWORD_COLOR
-            : builtins?.has(value)
-              ? BUILTIN_COLOR
-              : isCallable
-                ? IDENTIFIER_COLOR
-                : undefined,
-      });
-      cursor = IDENTIFIER_PATTERN.lastIndex;
-      continue;
-    }
-
-    tokens.push({ text: segment[cursor] ?? "" });
-    cursor += 1;
-  }
-
-  return tokens;
-}
-
-function findCommentStart(line: string, commentPrefix: string): number {
-  let quote: '"' | "'" | "`" | null = null;
-  let escaped = false;
-
-  for (let index = 0; index < line.length; index += 1) {
-    const character = line[index];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-        continue;
+      if (index < segments.length - 1) {
+        lines.push([]);
       }
-
-      if (character === "\\") {
-        escaped = true;
-        continue;
-      }
-
-      if (character === quote) {
-        quote = null;
-      }
-
-      continue;
-    }
-
-    if (character === '"' || character === "'" || character === "`") {
-      quote = character;
-      continue;
-    }
-
-    if (line.startsWith(commentPrefix, index)) {
-      return index;
     }
   }
 
-  return -1;
-}
-
-function findNextNonSpace(value: string, start: number): string | null {
-  for (let index = start; index < value.length; index += 1) {
-    const character = value[index];
-
-    if (!character) {
-      continue;
-    }
-
-    if (!/\s/.test(character)) {
-      return character;
-    }
-  }
-
-  return null;
+  return lines;
 }
 
 function coalesceTokens(tokens: CodeToken[]): CodeToken[] {
-  const first = tokens[0];
+  const merged: CodeToken[] = [];
 
-  if (!first) {
-    return tokens;
-  }
-
-  const merged: CodeToken[] = [first];
-
-  for (let index = 1; index < tokens.length; index += 1) {
+  for (const token of tokens) {
     const previous = merged[merged.length - 1];
-    const current = tokens[index];
 
-    if (!previous || !current) {
+    if (
+      previous &&
+      previous.color === token.color &&
+      previous.bold === token.bold &&
+      previous.italics === token.italics
+    ) {
+      previous.text += token.text;
       continue;
     }
 
-    if (previous.color === current.color) {
-      previous.text += current.text;
-      continue;
-    }
-
-    merged.push(current);
+    merged.push({ ...token });
   }
 
   return merged;


### PR DESCRIPTION
Fixes #5 

## Summary
- add syntax-highlighted fenced code block rendering for supported languages in generated DOCX output
- fall back to normal formatted code text when the fence language is missing or unsupported
- extend library and CLI tests and update the example markdown with code block samples

## Validation
- bun test
- bun run typecheck
- bun run lint
- bun run build