### PR TITLE
fix: support svg images and skip invalid assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `markdown-to-doc` should be documented in this file.
 
 The format is based on Keep a Changelog and this project uses semantic versioning.
 
+## [Unreleased]
+
+### Added
+
+- Added SVG image support for cover logos, cover images, header/footer image slots, and markdown images, including the fallback data required by `docx`.
+- Added regression tests covering SVG embedding and invalid image skipping.
+- Added an example SVG logo asset and updated the example script/markdown to exercise SVG rendering and skipped missing images.
+
+### Changed
+
+- Updated image rendering to skip assets with unsupported or mismatched image data instead of failing document generation.
+
 ## [1.1.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The repository includes a runnable example:
 bun run example
 ```
 
-That script reads `examples/example.md` and writes `examples/test-output.docx`.
+That script reads `examples/example.md`, embeds `examples/logo.svg`, skips the intentionally missing image entry, and writes `examples/test-output.docx`.
 
 ## Errors
 

--- a/examples/example.md
+++ b/examples/example.md
@@ -268,6 +268,10 @@ matched, grounded, useful
 
 ![Small badge-style image](https://picsum.photos/seed/docx-badge/120/40)
 
+![Local SVG logo](./logo.svg)
+
+![This missing image should be skipped](./missing-image.png)
+
 ## Problem statement
 
 Current payment-side API validation relies heavily on manual scripts, browser network-tab inspection, and developer familiarity with specific endpoints. This approach is difficult to scale for complex financial checks such as net worth reconciliation, category aggregation, recurring expense validation, and multi-source consistency checks. The meeting "API Testing Strategy Test" confirmed that current PM-agent-driven approaches are not sufficiently deterministic for data- and calculation-heavy workflows, while OpenAPI-based approaches remain underused due to tooling and documentation issues.

--- a/examples/logo.svg
+++ b/examples/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="80" viewBox="0 0 240 80">
+  <rect width="240" height="80" rx="14" fill="#1d4ed8" />
+  <circle cx="44" cy="40" r="18" fill="#ffffff" fill-opacity="0.18" />
+  <path d="M35 40h18" stroke="#ffffff" stroke-width="6" stroke-linecap="round" />
+  <path d="M44 31v18" stroke="#ffffff" stroke-width="6" stroke-linecap="round" />
+  <text x="78" y="35" fill="#ffffff" font-family="Arial, sans-serif" font-size="18" font-weight="700">
+    markdown-to-doc
+  </text>
+  <text x="78" y="56" fill="#dbeafe" font-family="Arial, sans-serif" font-size="12">
+    SVG example logo
+  </text>
+</svg>

--- a/examples/markdown-to-docx.ts
+++ b/examples/markdown-to-docx.ts
@@ -15,6 +15,7 @@ const markdown = await readFile(path.join(__dirname, "example.md"), "utf8");
 
 const buffer = await markdownToDocx(markdown, {
   assets: {
+    baseDir: __dirname,
     resolveImage: async ({ src }) => {
       if (src.startsWith("http://") || src.startsWith("https://")) {
         return {
@@ -46,6 +47,8 @@ const buffer = await markdownToDocx(markdown, {
     subtitle: "Generated from the public package API",
     projectName: "markdown-to-doc",
     date: "May 2026",
+    logo: { kind: "path", value: "./logo.svg" },
+    logoPosition: "top-right",
     image: { kind: "buffer", value: tinyPng },
     imageWidth: 440,
     imageHeight: 180,

--- a/src/__tests__/markdown-to-doc.test.ts
+++ b/src/__tests__/markdown-to-doc.test.ts
@@ -6,6 +6,9 @@ const tinyPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9l8AAAAASUVORK5CYII=",
   "base64",
 );
+const tinySvg = Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><rect width="24" height="24" fill="#2563eb"/></svg>',
+);
 
 async function openDocx(buffer: Buffer): Promise<JSZip> {
   return JSZip.loadAsync(buffer);
@@ -140,6 +143,45 @@ describe("markdownToDocx", () => {
 
     expect(resolverCalls).toBe(1);
     expect(mediaEntries.length).toBeGreaterThan(0);
+  });
+
+  it("embeds svg images with a docx fallback", async () => {
+    const buffer = await markdownToDocx("# Title", {
+      cover: {
+        show: true,
+        title: "SVG Cover",
+        logo: { kind: "buffer", value: tinySvg },
+      },
+    });
+
+    const zip = await openDocx(buffer);
+    const mediaEntries = Object.keys(zip.files).filter((entry) => entry.startsWith("word/media/"));
+
+    expect(mediaEntries.some((entry) => entry.endsWith(".svg"))).toBe(true);
+    expect(mediaEntries.some((entry) => entry.endsWith(".png"))).toBe(true);
+  });
+
+  it("skips invalid images instead of throwing", async () => {
+    const invalidImage = Buffer.from("not-an-image");
+    const buffer = await markdownToDocx("Before ![Broken](ignored) After", {
+      cover: {
+        show: true,
+        title: "Cover Title",
+        logo: { kind: "buffer", value: invalidImage },
+      },
+      assets: {
+        resolveImage: async () => invalidImage,
+      },
+    });
+
+    const zip = await openDocx(buffer);
+    const documentXml = await readZipText(zip, "word/document.xml");
+    const mediaEntries = Object.keys(zip.files).filter((entry) => entry.startsWith("word/media/"));
+
+    expect(documentXml).toContain("Cover Title");
+    expect(documentXml).toContain("Before ");
+    expect(documentXml).toContain(" After");
+    expect(mediaEntries).toHaveLength(0);
   });
 
   it("renders centered cover content and embeds a cover image", async () => {

--- a/src/markdown-to-doc.ts
+++ b/src/markdown-to-doc.ts
@@ -51,7 +51,11 @@ import type {
 } from "./types/markdown-to-doc.types.js";
 import { tokenizeCodeBlock } from "./utils/code-highlighting.js";
 import { resolveOptions } from "./utils/default-options.js";
-import { resolveConfiguredImage, resolveMarkdownImage } from "./utils/image.js";
+import {
+  type SizedImage,
+  tryResolveConfiguredImage,
+  tryResolveMarkdownImage,
+} from "./utils/image.js";
 import { extractText, parseMarkdown } from "./utils/markdown.js";
 
 type SectionChild = Paragraph | Table | TableOfContents;
@@ -198,29 +202,26 @@ async function buildCoverPage(context: RenderContext): Promise<Paragraph[]> {
   const coverAlignment = cover.alignment === "left" ? AlignmentType.LEFT : AlignmentType.CENTER;
 
   if (cover.logo) {
-    const image = await resolveConfiguredImage(cover.logo, assets.baseDir);
-    const alignment =
-      cover.logoPosition === "top-center"
-        ? AlignmentType.CENTER
-        : cover.logoPosition === "top-right"
-          ? AlignmentType.RIGHT
-          : AlignmentType.LEFT;
+    const image = await tryResolveConfiguredImage(cover.logo, assets.baseDir);
 
-    children.push(
-      new Paragraph({
-        alignment,
-        spacing: {
-          after: toTwips(24),
-        },
-        children: [
-          new ImageRun({
-            type: image.type,
-            data: image.data,
-            transformation: scaleToFit(image.width, image.height, 180),
-          }),
-        ],
-      }),
-    );
+    if (image) {
+      const alignment =
+        cover.logoPosition === "top-center"
+          ? AlignmentType.CENTER
+          : cover.logoPosition === "top-right"
+            ? AlignmentType.RIGHT
+            : AlignmentType.LEFT;
+
+      children.push(
+        new Paragraph({
+          alignment,
+          spacing: {
+            after: toTwips(24),
+          },
+          children: [createImageRun(image, scaleToFit(image.width, image.height, 180))],
+        }),
+      );
+    }
   }
 
   children.push(
@@ -232,7 +233,11 @@ async function buildCoverPage(context: RenderContext): Promise<Paragraph[]> {
   );
 
   if (cover.image && cover.imagePosition === "aboveTitle") {
-    children.push(await createCoverImageParagraph(context));
+    const coverImageParagraph = await createCoverImageParagraph(context);
+
+    if (coverImageParagraph) {
+      children.push(coverImageParagraph);
+    }
   }
 
   if (cover.title) {
@@ -278,7 +283,11 @@ async function buildCoverPage(context: RenderContext): Promise<Paragraph[]> {
   }
 
   if (cover.image && cover.imagePosition === "belowTitle") {
-    children.push(await createCoverImageParagraph(context));
+    const coverImageParagraph = await createCoverImageParagraph(context);
+
+    if (coverImageParagraph) {
+      children.push(coverImageParagraph);
+    }
   }
 
   if (cover.projectName) {
@@ -292,14 +301,19 @@ async function buildCoverPage(context: RenderContext): Promise<Paragraph[]> {
   return children;
 }
 
-async function createCoverImageParagraph(context: RenderContext): Promise<Paragraph> {
+async function createCoverImageParagraph(context: RenderContext): Promise<Paragraph | null> {
   const { cover, assets } = context.options;
 
   if (!cover.image) {
-    return new Paragraph({});
+    return null;
   }
 
-  const image = await resolveConfiguredImage(cover.image, assets.baseDir);
+  const image = await tryResolveConfiguredImage(cover.image, assets.baseDir);
+
+  if (!image) {
+    return null;
+  }
+
   const maxWidth = Math.min(context.contentWidthPx, 420);
 
   return new Paragraph({
@@ -308,17 +322,15 @@ async function createCoverImageParagraph(context: RenderContext): Promise<Paragr
       after: toTwips(18),
     },
     children: [
-      new ImageRun({
-        type: image.type,
-        data: image.data,
-        transformation:
-          cover.imageWidth && cover.imageHeight
-            ? {
-                width: cover.imageWidth,
-                height: cover.imageHeight,
-              }
-            : scaleToFit(image.width, image.height, maxWidth),
-      }),
+      createImageRun(
+        image,
+        cover.imageWidth && cover.imageHeight
+          ? {
+              width: cover.imageWidth,
+              height: cover.imageHeight,
+            }
+          : scaleToFit(image.width, image.height, maxWidth),
+      ),
     ],
   });
 }
@@ -425,7 +437,7 @@ async function renderHeaderFooterSlot(
       : undefined;
 
   if (slot.type === "image") {
-    const image = await resolveConfiguredImage(slot.source, context.options.assets.baseDir);
+    const image = await tryResolveConfiguredImage(slot.source, context.options.assets.baseDir);
 
     return new Paragraph({
       alignment,
@@ -433,16 +445,16 @@ async function renderHeaderFooterSlot(
         before: toTwips(1),
         after: toTwips(1),
       },
-      children: [
-        new ImageRun({
-          type: image.type,
-          data: image.data,
-          transformation:
-            slot.width && slot.height
-              ? { width: slot.width, height: slot.height }
-              : scaleToFit(image.width, image.height, slot.width ?? 120),
-        }),
-      ],
+      children: image
+        ? [
+            createImageRun(
+              image,
+              slot.width && slot.height
+                ? { width: slot.width, height: slot.height }
+                : scaleToFit(image.width, image.height, slot.width ?? 120),
+            ),
+          ]
+        : [],
     });
   }
 
@@ -697,7 +709,11 @@ async function renderInline(
     }
 
     if (node.type === "image") {
-      children.push(await renderImage(node, context));
+      const image = await renderImage(node, context);
+
+      if (image) {
+        children.push(image);
+      }
     }
   }
 
@@ -735,8 +751,8 @@ async function renderLink(
   });
 }
 
-async function renderImage(node: Image, context: RenderContext): Promise<ImageRun> {
-  const image = await resolveMarkdownImage(
+async function renderImage(node: Image, context: RenderContext): Promise<ImageRun | null> {
+  const image = await tryResolveMarkdownImage(
     {
       src: node.url,
       alt: node.alt || undefined,
@@ -745,17 +761,46 @@ async function renderImage(node: Image, context: RenderContext): Promise<ImageRu
     context.options.assets,
   );
 
+  if (!image) {
+    return null;
+  }
+
   const maxWidth = Math.min(context.contentWidthPx, 520);
+
+  return createImageRun(image, scaleToFit(image.width, image.height, maxWidth), {
+    name: node.alt || "markdown-image",
+    description: node.alt || "",
+    title: node.title || node.alt || "",
+  });
+}
+
+function createImageRun(
+  image: SizedImage,
+  transformation: { width: number; height: number },
+  altText?: { name: string; description: string; title: string },
+): ImageRun {
+  if (image.type === "svg") {
+    if (!image.fallback) {
+      throw new MarkdownToDocError("SVG image fallback is required.");
+    }
+
+    return new ImageRun({
+      type: image.type,
+      data: image.data,
+      fallback: {
+        type: image.fallback.type,
+        data: image.fallback.data,
+      },
+      transformation,
+      altText,
+    });
+  }
 
   return new ImageRun({
     type: image.type,
     data: image.data,
-    transformation: scaleToFit(image.width, image.height, maxWidth),
-    altText: {
-      name: node.alt || "markdown-image",
-      description: node.alt || "",
-      title: node.title || node.alt || "",
-    },
+    transformation,
+    altText,
   });
 }
 

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -7,12 +7,22 @@ import type { AssetOptions, ImageSource, ResolvedImage } from "../types/markdown
 
 const DATA_URL_PATTERN = /^data:(?<mime>image\/[a-zA-Z0-9.+-]+);base64,(?<data>.+)$/;
 const REMOTE_URL_PATTERN = /^https?:\/\//i;
+const TRANSPARENT_PNG_FALLBACK = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9l8AAAAASUVORK5CYII=",
+  "base64",
+);
+
+type SupportedImageType = "jpg" | "png" | "gif" | "bmp" | "svg";
 
 export interface SizedImage {
   data: Buffer;
   width: number;
   height: number;
-  type: "jpg" | "png" | "gif" | "bmp";
+  type: SupportedImageType;
+  fallback?: {
+    data: Buffer;
+    type: "png";
+  };
 }
 
 /**
@@ -33,6 +43,17 @@ export async function resolveConfiguredImage(
   return withMeasuredSize({
     data: await readFile(path.resolve(baseDir, source.value)),
   });
+}
+
+export async function tryResolveConfiguredImage(
+  source: ImageSource,
+  baseDir: string,
+): Promise<SizedImage | null> {
+  try {
+    return await resolveConfiguredImage(source, baseDir);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -90,11 +111,35 @@ export async function resolveMarkdownImage(
   });
 }
 
+export async function tryResolveMarkdownImage(
+  input: { src: string; alt?: string; title?: string },
+  assets: Required<AssetOptions>,
+): Promise<SizedImage | null> {
+  try {
+    return await resolveMarkdownImage(input, assets);
+  } catch {
+    return null;
+  }
+}
+
 function withMeasuredSize(image: ResolvedImage): SizedImage {
   const size = imageSize(image.data);
 
   if (!size.width || !size.height || !size.type) {
     throw new MarkdownToDocError("Unable to determine image dimensions.");
+  }
+
+  if (size.type === "svg") {
+    return {
+      data: image.data,
+      width: image.width ?? size.width,
+      height: image.height ?? size.height,
+      type: size.type,
+      fallback: {
+        data: TRANSPARENT_PNG_FALLBACK,
+        type: "png",
+      },
+    };
   }
 
   if (!["jpg", "png", "gif", "bmp"].includes(size.type)) {


### PR DESCRIPTION
## Summary
- add SVG support for configured and markdown images, including the fallback payload required by `docx`
- skip invalid or type-mismatched images instead of throwing so unsupported logos and images are omitted from the output
- add regression coverage, update the example assets, and document the change in the changelog

## Validation
- bun run ci:check
- bun run example

Closes #10